### PR TITLE
feat(auth): global context + header/home auth UX (Closes #59)

### DIFF
--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 
     if (existingUser) {
       return NextResponse.json(
-        { error: "Este email ja esta registrado" },
+        { error: "Credencial invalida" },
         { status: 400 }
       );
     }

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -4,9 +4,11 @@ import type { ChangeEvent, FormEvent } from "react";
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/components/auth-context";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { login } = useAuth();
   const [formData, setFormData] = useState({
     email: "",
     password: "",
@@ -41,8 +43,7 @@ export default function LoginPage() {
         return;
       }
 
-      localStorage.setItem("authToken", data.token);
-      localStorage.setItem("user", JSON.stringify(data.user));
+      login(data.token, data.user);
 
       router.push("/");
     } catch (err) {

--- a/web/src/app/auth/register/page.tsx
+++ b/web/src/app/auth/register/page.tsx
@@ -4,9 +4,11 @@ import type { ChangeEvent, FormEvent } from "react";
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/components/auth-context";
 
 export default function RegisterPage() {
   const router = useRouter();
+  const { login } = useAuth();
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -50,8 +52,7 @@ export default function RegisterPage() {
         return;
       }
 
-      localStorage.setItem("authToken", data.token);
-      localStorage.setItem("user", JSON.stringify(data.user));
+      login(data.token, data.user);
 
       router.push("/");
     } catch (err) {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import AuthStatus from "@/components/auth-status";
+import { AuthProvider } from "@/components/auth-context";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,12 +30,14 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <header className="w-full border-b border-zinc-200 px-4 py-3">
-          <div className="mx-auto flex w-full max-w-6xl justify-end">
-            <AuthStatus />
-          </div>
-        </header>
-        <main className="flex-1">{children}</main>
+        <AuthProvider>
+          <header className="w-full border-b border-zinc-200 px-4 py-3">
+            <div className="mx-auto flex w-full max-w-6xl justify-end">
+              <AuthStatus />
+            </div>
+          </header>
+          <main className="flex-1">{children}</main>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 export default function Home() {
@@ -8,12 +10,6 @@ export default function Home() {
       <div className="flex gap-3">
         <Link href="/produtos" className="rounded border border-zinc-300 px-4 py-2">
           Ver produtos
-        </Link>
-        <Link href="/auth/login" className="rounded bg-zinc-900 px-4 py-2 text-white">
-          Entrar
-        </Link>
-        <Link href="/auth/register" className="rounded border border-zinc-300 px-4 py-2">
-          Criar conta
         </Link>
       </div>
     </div>

--- a/web/src/components/auth-context.tsx
+++ b/web/src/components/auth-context.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type AuthUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  login: (token: string, user: AuthUser) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function readStoredUser(): AuthUser | null {
+  const rawUser = localStorage.getItem("user");
+  if (!rawUser) return null;
+
+  try {
+    const parsed = JSON.parse(rawUser) as Partial<AuthUser>;
+    if (!parsed.id || !parsed.email) return null;
+
+    return {
+      id: parsed.id,
+      name: parsed.name?.trim() || "Usuario",
+      email: parsed.email,
+      role: parsed.role || "USER",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+
+  const syncFromStorage = useCallback(() => {
+    setUser(readStoredUser());
+  }, []);
+
+  useEffect(() => {
+    syncFromStorage();
+
+    const onStorageOrFocus = () => syncFromStorage();
+    window.addEventListener("storage", onStorageOrFocus);
+    window.addEventListener("focus", onStorageOrFocus);
+
+    return () => {
+      window.removeEventListener("storage", onStorageOrFocus);
+      window.removeEventListener("focus", onStorageOrFocus);
+    };
+  }, [syncFromStorage]);
+
+  const login = useCallback((token: string, nextUser: AuthUser) => {
+    localStorage.setItem("authToken", token);
+    localStorage.setItem("user", JSON.stringify(nextUser));
+    setUser({
+      id: nextUser.id,
+      name: nextUser.name?.trim() || "Usuario",
+      email: nextUser.email,
+      role: nextUser.role || "USER",
+    });
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("user");
+    setUser(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      isAuthenticated: !!user,
+      login,
+      logout,
+    }),
+    [user, login, logout]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth deve ser usado dentro de AuthProvider");
+  }
+  return context;
+}

--- a/web/src/components/auth-status.tsx
+++ b/web/src/components/auth-status.tsx
@@ -1,44 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-
-type StoredUser = {
-  name?: string;
-};
+import { useAuth } from "@/components/auth-context";
 
 export default function AuthStatus() {
   const router = useRouter();
-  const [userName, setUserName] = useState<string | null>(null);
-
-  useEffect(() => {
-    const rawUser = localStorage.getItem("user");
-    if (!rawUser) {
-      setUserName(null);
-      return;
-    }
-
-    try {
-      const parsedUser = JSON.parse(rawUser) as StoredUser;
-      setUserName(parsedUser.name?.trim() || "Usuario");
-    } catch {
-      setUserName(null);
-    }
-  }, []);
+  const { user, logout } = useAuth();
 
   const handleLogout = () => {
-    localStorage.removeItem("authToken");
-    localStorage.removeItem("user");
-    setUserName(null);
+    logout();
     router.push("/");
   };
 
-  if (userName) {
+  if (user) {
     return (
       <div className="flex items-center gap-2">
         <div className="rounded-full border border-zinc-300 px-3 py-1.5 text-sm font-medium">
-          {userName}
+          {user.name}
         </div>
         <button
           type="button"


### PR DESCRIPTION
## Summary\n- adiciona AuthProvider e hook useAuth global\n- integra layout e auth-status com estado global\n- login/register passam a usar context para atualizar UI imediatamente\n- home remove botoes de entrar/criar conta\n- padroniza mensagem generica de credencial no registro\n\nCloses #59