### PR TITLE
fix(ci): corrigir npm ci quebrando no prisma postinstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          DATABASE_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder
 
       - name: Generate Prisma Client
         run: npx prisma generate

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Generate Prisma Client
         run: npx prisma generate


### PR DESCRIPTION
## Problema
O job de CI estava falhando no passo de install (pm ci) porque o postinstall executa prisma generate sem DATABASE_URL definida nesse momento.

## Solucao
- Definida DATABASE_URL no passo **Install dependencies** em .github/workflows/ci.yml.
- Aplicado o mesmo ajuste em .github/workflows/migrate.yml.\n\n## Issue\nCloses #74\n