### PR TITLE
fix(cart): criar carrinho automaticamente

### DIFF
--- a/web/src/app/api/cart/items/route.ts
+++ b/web/src/app/api/cart/items/route.ts
@@ -38,10 +38,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const cart = await prisma.cart.findUnique({ where: { userId: payload.userId } });
-    if (!cart) {
-      return NextResponse.json({ error: "Carrinho nao encontrado" }, { status: 404 });
-    }
+    const cart = await prisma.cart.upsert({
+      where: { userId: payload.userId },
+      update: {},
+      create: { userId: payload.userId },
+    });
 
     const existingItem = await prisma.cartItem.findUnique({
       where: { cartId_productId: { cartId: cart.id, productId } },

--- a/web/src/app/api/cart/route.ts
+++ b/web/src/app/api/cart/route.ts
@@ -14,8 +14,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Token invalido" }, { status: 401 });
     }
 
-    const cart = await prisma.cart.findUnique({
+    const cart = await prisma.cart.upsert({
       where: { userId: payload.userId },
+      update: {},
+      create: { userId: payload.userId },
       include: {
         items: {
           include: {
@@ -34,10 +36,6 @@ export async function GET(request: NextRequest) {
         },
       },
     });
-
-    if (!cart) {
-      return NextResponse.json({ error: "Carrinho nao encontrado" }, { status: 404 });
-    }
 
     const total = cart.items.reduce(
       (sum, item) => sum + Number(item.product.price) * item.quantity,
@@ -77,11 +75,9 @@ export async function DELETE(request: NextRequest) {
       where: { userId: payload.userId },
     });
 
-    if (!cart) {
-      return NextResponse.json({ error: "Carrinho nao encontrado" }, { status: 404 });
+    if (cart) {
+      await prisma.cartItem.deleteMany({ where: { cartId: cart.id } });
     }
-
-    await prisma.cartItem.deleteMany({ where: { cartId: cart.id } });
 
     return NextResponse.json({ message: "Carrinho limpo com sucesso" });
   } catch (error) {


### PR DESCRIPTION
## Summary

- POST /api/cart/items retornava 404 \"Carrinho nao encontrado\" para users sem registro em Cart
- Seed cria carts apenas para 3 users demo; users novos via register ficavam travados
- Fix com upsert nas rotas de cart

## Test plan

- [x] Adicionar produto via home com user recem-registrado nao da mais 404
- [x] GET /api/cart retorna cart vazio em vez de 404
- [x] DELETE /api/cart tolera ausencia de cart

🤖 Generated with [Claude Code](https://claude.com/claude-code)